### PR TITLE
Fix after xxxx callbacks deprecation

### DIFF
--- a/conditional_counter_cache.gemspec
+++ b/conditional_counter_cache.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rails"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "3.0.2"
+  spec.add_development_dependency "rspec", "3.1.0"
   spec.add_development_dependency "rspec-rails"
 end

--- a/lib/conditional_counter_cache/belongs_to.rb
+++ b/lib/conditional_counter_cache/belongs_to.rb
@@ -33,10 +33,10 @@ module ConditionalCounterCache
 
           if (@_after_create_counter_called ||= false)
             @_after_create_counter_called = false
-          elsif attribute_changed?(foreign_key) && !new_record? && reflection.constructable?
+          elsif saved_change_to_attribute?(foreign_key) && !new_record? && reflection.constructable?
             return unless reflection.has_countable?(self)
             model           = reflection.klass
-            foreign_key_was = attribute_was foreign_key
+            foreign_key_was = attribute_before_last_save foreign_key
             foreign_key     = attribute foreign_key
 
             if foreign_key && model.respond_to?(:increment_counter)


### PR DESCRIPTION
Remove deprecations.

[Deprecate the behavior of AR::Dirty inside of after\_\(create\|update\|save\) callbacks by sgrif · Pull Request \#25337 · rails/rails](https://github.com/rails/rails/pull/25337)